### PR TITLE
Make chat defocus and hiding better

### DIFF
--- a/NitroxClient/MonoBehaviours/Gui/Chat/PlayerChatInputField.cs
+++ b/NitroxClient/MonoBehaviours/Gui/Chat/PlayerChatInputField.cs
@@ -82,9 +82,8 @@ namespace NitroxClient.MonoBehaviours.Gui.Chat
 
             if (selected)
             {
-                if (!string.IsNullOrEmpty(InputField.text))
+                if (!string.IsNullOrEmpty(InputField.text) && !string.IsNullOrWhiteSpace(InputField.text))
                 {
-                    ResetTimer();
                     if (UnityEngine.Input.GetKey(KeyCode.Return))
                     {
                         if (UnityEngine.Input.GetKey(KeyCode.LeftShift))
@@ -115,6 +114,14 @@ namespace NitroxClient.MonoBehaviours.Gui.Chat
                             playerChatManager.SendMessage();
                             playerChatManager.DeselectChat(); // return to game after message sent
                         }
+                    }
+                }
+                else
+                {
+                    if (UnityEngine.Input.GetKey(KeyCode.Return))
+                    {
+                        ResetTimer();
+                        playerChatManager.DeselectChat();
                     }
                 }
 
@@ -153,12 +160,6 @@ namespace NitroxClient.MonoBehaviours.Gui.Chat
                     playerChatManager.HideChat();
                     FreezeTime = true;
                 }
-            }
-
-            // Reselect chat if Y is pressed
-            if (UnityEngine.Input.GetKeyDown(KeyCode.Y))
-            {
-                playerChatManager.SelectChat();
             }
         }
 


### PR DESCRIPTION
in scenarios such as:
 - an actual message was sent
 - no message was sent (null or empty)
 - message contains only whitespaces

With these changes, the hardcoded "Y" key bind is also no longer needed and I believe the desired functionality is met.